### PR TITLE
Dockerfile-Ubtuntu16.04

### DIFF
--- a/Dockerfile-Ubuntu16.04
+++ b/Dockerfile-Ubuntu16.04
@@ -1,0 +1,9 @@
+FROM ubuntu:16.04
+
+RUN apt-get update \
+&& apt-get install python3 -y \
+&& apt-get install python3-pip -y \
+&& apt-get install libgmp3-dev -y \
+&& apt-get install -y libmpfr-dev libmpfr-doc libmpfr4 libmpfr4-dbg \
+&& apt-get install libmpc-dev -y \
+&& pip3 install phe


### PR DESCRIPTION
Include Dockerfile for ease of use and to avoid issues while installing dependencies (gmp,mfr, mpc). A working image can be found at: https://hub.docker.com/r/rbinrais/python-paillier