### PR TITLE
Move encoding into own file

### DIFF
--- a/docs/phe.rst
+++ b/docs/phe.rst
@@ -11,6 +11,15 @@ Paillier
     :undoc-members:
     :show-inheritance:
 
+Encoding
+--------
+
+.. automodule:: phe.encoding
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
 
 Utilities
 ---------
@@ -21,12 +30,3 @@ Utilities
     :undoc-members:
     :show-inheritance:
 
-
-CLI
-----
-
-
-.. automodule:: phe.command_line
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/examples/alternative_base.py
+++ b/examples/alternative_base.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3.4
 import math
+
+import phe.encoding
 from phe import paillier
 
 
-class ExampleEncodedNumber(paillier.EncodedNumber):
+class ExampleEncodedNumber(phe.encoding.EncodedNumber):
     BASE = 64
     LOG2_BASE = math.log(BASE, 2)
 

--- a/phe/__init__.py
+++ b/phe/__init__.py
@@ -1,10 +1,11 @@
 import pkg_resources
 
+from phe.encoding import EncodedNumber
 from phe.paillier import generate_paillier_keypair
-from phe.paillier import EncodedNumber
 from phe.paillier import EncryptedNumber
 from phe.paillier import PaillierPrivateKey, PaillierPublicKey
 from phe.paillier import PaillierPrivateKeyring
+
 import phe.util
 
 try:

--- a/phe/encoding.py
+++ b/phe/encoding.py
@@ -1,0 +1,252 @@
+import math
+import sys
+
+
+class EncodedNumber(object):
+    """Represents a float or int encoded for Paillier encryption.
+
+    For end users, this class is mainly useful for specifying precision
+    when adding/multiplying an :class:`EncryptedNumber` by a scalar.
+
+    If you want to manually encode a number for Paillier encryption,
+    then use :meth:`encode`, if de-serializing then use
+    :meth:`__init__`.
+
+
+    .. note::
+        If working with other Paillier libraries you will have to agree on
+        a specific :attr:`BASE` and :attr:`LOG2_BASE` - inheriting from this
+        class and overriding those two attributes will enable this.
+
+    Notes:
+      Paillier encryption is only defined for non-negative integers less
+      than :attr:`PaillierPublicKey.n`. Since we frequently want to use
+      signed integers and/or floating point numbers (luxury!), values
+      should be encoded as a valid integer before encryption.
+
+      The operations of addition and multiplication [1]_ must be
+      preserved under this encoding. Namely:
+
+      1. Decode(Encode(a) + Encode(b)) = a + b
+      2. Decode(Encode(a) * Encode(b)) = a * b
+
+      for any real numbers a and b.
+
+      Representing signed integers is relatively easy: we exploit the
+      modular arithmetic properties of the Paillier scheme. We choose to
+      represent only integers between
+      +/-:attr:`~PaillierPublicKey.max_int`, where `max_int` is
+      approximately :attr:`~PaillierPublicKey.n`/3 (larger integers may
+      be treated as floats). The range of values between `max_int` and
+      `n` - `max_int` is reserved for detecting overflows. This encoding
+      scheme supports properties #1 and #2 above.
+
+      Representing floating point numbers as integers is a harder task.
+      Here we use a variant of fixed-precision arithmetic. In fixed
+      precision, you encode by multiplying every float by a large number
+      (e.g. 1e6) and rounding the resulting product. You decode by
+      dividing by that number. However, this encoding scheme does not
+      satisfy property #2 above: upon every multiplication, you must
+      divide by the large number. In a Paillier scheme, this is not
+      possible to do without decrypting. For some tasks, this is
+      acceptable or can be worked around, but for other tasks this can't
+      be worked around.
+
+      In our scheme, the "large number" is allowed to vary, and we keep
+      track of it. It is:
+
+        :attr:`BASE` ** :attr:`exponent`
+
+      One number has many possible encodings; this property can be used
+      to mitigate the leak of information due to the fact that
+      :attr:`exponent` is never encrypted.
+
+      For more details, see :meth:`encode`.
+
+    .. rubric:: Footnotes
+
+    ..  [1] Technically, since Paillier encryption only supports
+      multiplication by a scalar, it may be possible to define a
+      secondary encoding scheme `Encode'` such that property #2 is
+      relaxed to:
+
+        Decode(Encode(a) * Encode'(b)) = a * b
+
+      We don't do this.
+
+
+    Args:
+      public_key (PaillierPublicKey): public key for which to encode
+        (this is necessary because :attr:`~PaillierPublicKey.max_int`
+        varies)
+      encoding (int): The encoded number to store. Must be positive and
+        less than :attr:`~PaillierPublicKey.max_int`.
+      exponent (int): Together with :attr:`BASE`, determines the level
+        of fixed-precision used in encoding the number.
+
+    Attributes:
+      public_key (PaillierPublicKey): public key for which to encode
+        (this is necessary because :attr:`~PaillierPublicKey.max_int`
+        varies)
+      encoding (int): The encoded number to store. Must be positive and
+        less than :attr:`~PaillierPublicKey.max_int`.
+      exponent (int): Together with :attr:`BASE`, determines the level
+        of fixed-precision used in encoding the number.
+    """
+    BASE = 16
+    """Base to use when exponentiating. Larger `BASE` means
+    that :attr:`exponent` leaks less information. If you vary this,
+    you'll have to manually inform anyone decoding your numbers.
+    """
+    LOG2_BASE = math.log(BASE, 2)
+    FLOAT_MANTISSA_BITS = sys.float_info.mant_dig
+
+    def __init__(self, public_key, encoding, exponent):
+        self.public_key = public_key
+        self.encoding = encoding
+        self.exponent = exponent
+
+    @classmethod
+    def encode(cls, public_key, scalar, precision=None, max_exponent=None):
+        """Return an encoding of an int or float.
+
+        This encoding is carefully chosen so that it supports the same
+        operations as the Paillier cryptosystem.
+
+        If *scalar* is a float, first approximate it as an int, `int_rep`:
+
+            scalar = int_rep * (:attr:`BASE` ** :attr:`exponent`),
+
+        for some (typically negative) integer exponent, which can be
+        tuned using *precision* and *max_exponent*. Specifically,
+        :attr:`exponent` is chosen to be equal to or less than
+        *max_exponent*, and such that the number *precision* is not
+        rounded to zero.
+
+        Having found an integer representation for the float (or having
+        been given an int `scalar`), we then represent this integer as
+        a non-negative integer < :attr:`~PaillierPublicKey.n`.
+
+        Paillier homomorphic arithemetic works modulo
+        :attr:`~PaillierPublicKey.n`. We take the convention that a
+        number x < n/3 is positive, and that a number x > 2n/3 is
+        negative. The range n/3 < x < 2n/3 allows for overflow
+        detection.
+
+        Args:
+          public_key (PaillierPublicKey): public key for which to encode
+            (this is necessary because :attr:`~PaillierPublicKey.n`
+            varies).
+          scalar: an int or float to be encrypted.
+            If int, it must satisfy abs(*value*) <
+            :attr:`~PaillierPublicKey.n`/3.
+            If float, it must satisfy abs(*value* / *precision*) <<
+            :attr:`~PaillierPublicKey.n`/3
+            (i.e. if a float is near the limit then detectable
+            overflow may still occur)
+          precision (float): Choose exponent (i.e. fix the precision) so
+            that this number is distinguishable from zero. If `scalar`
+            is a float, then this is set so that minimal precision is
+            lost. Lower precision leads to smaller encodings, which
+            might yield faster computation.
+          max_exponent (int): Ensure that the exponent of the returned
+            `EncryptedNumber` is at most this.
+
+        Returns:
+          EncodedNumber: Encoded form of *scalar*, ready for encryption
+          against *public_key*.
+        """
+        # Calculate the maximum exponent for desired precision
+        if precision is None:
+            if isinstance(scalar, int):
+                prec_exponent = 0
+            elif isinstance(scalar, float):
+                # Encode with *at least* as much precision as the python float
+                # What's the base-2 exponent on the float?
+                bin_flt_exponent = math.frexp(scalar)[1]
+
+                # What's the base-2 exponent of the least significant bit?
+                # The least significant bit has value 2 ** bin_lsb_exponent
+                bin_lsb_exponent = bin_flt_exponent - cls.FLOAT_MANTISSA_BITS
+
+                # What's the corresponding base BASE exponent? Round that down.
+                prec_exponent = math.floor(bin_lsb_exponent / cls.LOG2_BASE)
+            else:
+                raise TypeError("Don't know the precision of type %s."
+                                % type(scalar))
+        else:
+            prec_exponent = math.floor(math.log(precision, cls.BASE))
+
+        # Remember exponents are negative for numbers < 1.
+        # If we're going to store numbers with a more negative
+        # exponent than demanded by the precision, then we may
+        # as well bump up the actual precision.
+        if max_exponent is None:
+            exponent = prec_exponent
+        else:
+            exponent = min(max_exponent, prec_exponent)
+
+        int_rep = int(round(scalar * pow(cls.BASE, -exponent)))
+
+        if abs(int_rep) > public_key.max_int:
+            raise ValueError('Integer needs to be within +/- %d but got %d'
+                             % (public_key.max_int, int_rep))
+
+        # Wrap negative numbers by adding n
+        return cls(public_key, int_rep % public_key.n, exponent)
+
+    def decode(self):
+        """Decode plaintext and return the result.
+
+        Returns:
+          an int or float: the decoded number. N.B. if the number
+            returned is an integer, it will not be of type float.
+
+        Raises:
+          OverflowError: if overflow is detected in the decrypted number.
+        """
+        if self.encoding >= self.public_key.n:
+            # Should be mod n
+            raise ValueError('Attempted to decode corrupted number')
+        elif self.encoding <= self.public_key.max_int:
+            # Positive
+            mantissa = self.encoding
+        elif self.encoding >= self.public_key.n - self.public_key.max_int:
+            # Negative
+            mantissa = self.encoding - self.public_key.n
+        else:
+            raise OverflowError('Overflow detected in decrypted number')
+
+        return mantissa * pow(self.BASE, self.exponent)
+
+    def decrease_exponent_to(self, new_exp):
+        """Return an `EncodedNumber` with same value but lower exponent.
+
+        If we multiply the encoded value by :attr:`BASE` and decrement
+        :attr:`exponent`, then the decoded value does not change. Thus
+        we can almost arbitrarily ratchet down the exponent of an
+        :class:`EncodedNumber` - we only run into trouble when the encoded
+        integer overflows. There may not be a warning if this happens.
+
+        This is necessary when adding :class:`EncodedNumber` instances,
+        and can also be useful to hide information about the precision
+        of numbers - e.g. a protocol can fix the exponent of all
+        transmitted :class:`EncodedNumber` to some lower bound(s).
+
+        Args:
+          new_exp (int): the desired exponent.
+
+        Returns:
+          EncodedNumber: Instance with the same value and desired
+            exponent.
+
+        Raises:
+          ValueError: You tried to increase the exponent, which can't be
+            done without decryption.
+        """
+        if new_exp > self.exponent:
+            raise ValueError('New exponent %i should be more negative than'
+                             'old exponent %i' % (new_exp, self.exponent))
+        factor = pow(self.BASE, self.exponent - new_exp)
+        new_enc = self.encoding * factor % self.public_key.n
+        return self.__class__(self.public_key, new_enc, new_exp)

--- a/phe/paillier.py
+++ b/phe/paillier.py
@@ -19,13 +19,13 @@
 
 """Paillier encryption library for partially homomorphic encryption."""
 import random
-import math
-import sys
+
 try:
     from collections.abc import Mapping
 except ImportError:
     Mapping = dict
 
+from phe import EncodedNumber
 from phe.util import invert, powmod, getprimeover, isqrt
 
 DEFAULT_KEYSIZE = 2048
@@ -429,256 +429,6 @@ class PaillierPrivateKeyring(Mapping):
         return relevant_private_key.decrypt(encrypted_number)
 
 
-class EncodedNumber(object):
-    """Represents a float or int encoded for Paillier encryption.
-
-    For end users, this class is mainly useful for specifying precision
-    when adding/multiplying an :class:`EncryptedNumber` by a scalar.
-
-    If you want to manually encode a number for Paillier encryption,
-    then use :meth:`encode`, if de-serializing then use
-    :meth:`__init__`.
-
-
-    .. note::
-        If working with other Paillier libraries you will have to agree on
-        a specific :attr:`BASE` and :attr:`LOG2_BASE` - inheriting from this
-        class and overriding those two attributes will enable this.
-
-    Notes:
-      Paillier encryption is only defined for non-negative integers less
-      than :attr:`PaillierPublicKey.n`. Since we frequently want to use
-      signed integers and/or floating point numbers (luxury!), values
-      should be encoded as a valid integer before encryption.
-
-      The operations of addition and multiplication [1]_ must be
-      preserved under this encoding. Namely:
-
-      1. Decode(Encode(a) + Encode(b)) = a + b
-      2. Decode(Encode(a) * Encode(b)) = a * b
-
-      for any real numbers a and b.
-
-      Representing signed integers is relatively easy: we exploit the
-      modular arithmetic properties of the Paillier scheme. We choose to
-      represent only integers between
-      +/-:attr:`~PaillierPublicKey.max_int`, where `max_int` is
-      approximately :attr:`~PaillierPublicKey.n`/3 (larger integers may
-      be treated as floats). The range of values between `max_int` and
-      `n` - `max_int` is reserved for detecting overflows. This encoding
-      scheme supports properties #1 and #2 above.
-
-      Representing floating point numbers as integers is a harder task.
-      Here we use a variant of fixed-precision arithmetic. In fixed
-      precision, you encode by multiplying every float by a large number
-      (e.g. 1e6) and rounding the resulting product. You decode by
-      dividing by that number. However, this encoding scheme does not
-      satisfy property #2 above: upon every multiplication, you must
-      divide by the large number. In a Paillier scheme, this is not
-      possible to do without decrypting. For some tasks, this is
-      acceptable or can be worked around, but for other tasks this can't
-      be worked around.
-
-      In our scheme, the "large number" is allowed to vary, and we keep
-      track of it. It is:
-
-        :attr:`BASE` ** :attr:`exponent`
-
-      One number has many possible encodings; this property can be used
-      to mitigate the leak of information due to the fact that
-      :attr:`exponent` is never encrypted.
-
-      For more details, see :meth:`encode`.
-
-    .. rubric:: Footnotes
-
-    ..  [1] Technically, since Paillier encryption only supports
-      multiplication by a scalar, it may be possible to define a
-      secondary encoding scheme `Encode'` such that property #2 is
-      relaxed to:
-
-        Decode(Encode(a) * Encode'(b)) = a * b
-
-      We don't do this.
-
-
-    Args:
-      public_key (PaillierPublicKey): public key for which to encode
-        (this is necessary because :attr:`~PaillierPublicKey.max_int`
-        varies)
-      encoding (int): The encoded number to store. Must be positive and
-        less than :attr:`~PaillierPublicKey.max_int`.
-      exponent (int): Together with :attr:`BASE`, determines the level
-        of fixed-precision used in encoding the number.
-
-    Attributes:
-      public_key (PaillierPublicKey): public key for which to encode
-        (this is necessary because :attr:`~PaillierPublicKey.max_int`
-        varies)
-      encoding (int): The encoded number to store. Must be positive and
-        less than :attr:`~PaillierPublicKey.max_int`.
-      exponent (int): Together with :attr:`BASE`, determines the level
-        of fixed-precision used in encoding the number.
-    """
-    BASE = 16
-    """Base to use when exponentiating. Larger `BASE` means
-    that :attr:`exponent` leaks less information. If you vary this,
-    you'll have to manually inform anyone decoding your numbers.
-    """
-    LOG2_BASE = math.log(BASE, 2)
-    FLOAT_MANTISSA_BITS = sys.float_info.mant_dig
-
-    def __init__(self, public_key, encoding, exponent):
-        self.public_key = public_key
-        self.encoding = encoding
-        self.exponent = exponent
-
-    @classmethod
-    def encode(cls, public_key, scalar, precision=None, max_exponent=None):
-        """Return an encoding of an int or float.
-
-        This encoding is carefully chosen so that it supports the same
-        operations as the Paillier cryptosystem.
-
-        If *scalar* is a float, first approximate it as an int, `int_rep`:
-
-            scalar = int_rep * (:attr:`BASE` ** :attr:`exponent`),
-
-        for some (typically negative) integer exponent, which can be
-        tuned using *precision* and *max_exponent*. Specifically,
-        :attr:`exponent` is chosen to be equal to or less than
-        *max_exponent*, and such that the number *precision* is not
-        rounded to zero.
-
-        Having found an integer representation for the float (or having
-        been given an int `scalar`), we then represent this integer as
-        a non-negative integer < :attr:`~PaillierPublicKey.n`.
-
-        Paillier homomorphic arithemetic works modulo
-        :attr:`~PaillierPublicKey.n`. We take the convention that a
-        number x < n/3 is positive, and that a number x > 2n/3 is
-        negative. The range n/3 < x < 2n/3 allows for overflow
-        detection.
-
-        Args:
-          public_key (PaillierPublicKey): public key for which to encode
-            (this is necessary because :attr:`~PaillierPublicKey.n`
-            varies).
-          scalar: an int or float to be encrypted.
-            If int, it must satisfy abs(*value*) <
-            :attr:`~PaillierPublicKey.n`/3.
-            If float, it must satisfy abs(*value* / *precision*) <<
-            :attr:`~PaillierPublicKey.n`/3
-            (i.e. if a float is near the limit then detectable
-            overflow may still occur)
-          precision (float): Choose exponent (i.e. fix the precision) so
-            that this number is distinguishable from zero. If `scalar`
-            is a float, then this is set so that minimal precision is
-            lost. Lower precision leads to smaller encodings, which
-            might yield faster computation.
-          max_exponent (int): Ensure that the exponent of the returned
-            `EncryptedNumber` is at most this.
-
-        Returns:
-          EncodedNumber: Encoded form of *scalar*, ready for encryption
-          against *public_key*.
-        """
-        # Calculate the maximum exponent for desired precision
-        if precision is None:
-            if isinstance(scalar, int):
-                prec_exponent = 0
-            elif isinstance(scalar, float):
-                # Encode with *at least* as much precision as the python float
-                # What's the base-2 exponent on the float?
-                bin_flt_exponent = math.frexp(scalar)[1]
-
-                # What's the base-2 exponent of the least significant bit?
-                # The least significant bit has value 2 ** bin_lsb_exponent
-                bin_lsb_exponent = bin_flt_exponent - cls.FLOAT_MANTISSA_BITS
-
-                # What's the corresponding base BASE exponent? Round that down.
-                prec_exponent = math.floor(bin_lsb_exponent / cls.LOG2_BASE)
-            else:
-                raise TypeError("Don't know the precision of type %s."
-                                % type(scalar))
-        else:
-            prec_exponent = math.floor(math.log(precision, cls.BASE))
-
-        # Remember exponents are negative for numbers < 1.
-        # If we're going to store numbers with a more negative
-        # exponent than demanded by the precision, then we may
-        # as well bump up the actual precision.
-        if max_exponent is None:
-            exponent = prec_exponent
-        else:
-            exponent = min(max_exponent, prec_exponent)
-
-        int_rep = int(round(scalar * pow(cls.BASE, -exponent)))
-
-        if abs(int_rep) > public_key.max_int:
-            raise ValueError('Integer needs to be within +/- %d but got %d'
-                             % (public_key.max_int, int_rep))
-
-        # Wrap negative numbers by adding n
-        return cls(public_key, int_rep % public_key.n, exponent)
-
-    def decode(self):
-        """Decode plaintext and return the result.
-
-        Returns:
-          an int or float: the decoded number. N.B. if the number
-            returned is an integer, it will not be of type float.
-
-        Raises:
-          OverflowError: if overflow is detected in the decrypted number.
-        """
-        if self.encoding >= self.public_key.n:
-            # Should be mod n
-            raise ValueError('Attempted to decode corrupted number')
-        elif self.encoding <= self.public_key.max_int:
-            # Positive
-            mantissa = self.encoding
-        elif self.encoding >= self.public_key.n - self.public_key.max_int:
-            # Negative
-            mantissa = self.encoding - self.public_key.n
-        else:
-            raise OverflowError('Overflow detected in decrypted number')
-
-        return mantissa * pow(self.BASE, self.exponent)
-
-    def decrease_exponent_to(self, new_exp):
-        """Return an `EncodedNumber` with same value but lower exponent.
-
-        If we multiply the encoded value by :attr:`BASE` and decrement
-        :attr:`exponent`, then the decoded value does not change. Thus
-        we can almost arbitrarily ratchet down the exponent of an
-        :class:`EncodedNumber` - we only run into trouble when the encoded
-        integer overflows. There may not be a warning if this happens.
-
-        This is necessary when adding :class:`EncodedNumber` instances,
-        and can also be useful to hide information about the precision
-        of numbers - e.g. a protocol can fix the exponent of all
-        transmitted :class:`EncodedNumber` to some lower bound(s).
-
-        Args:
-          new_exp (int): the desired exponent.
-
-        Returns:
-          EncodedNumber: Instance with the same value and desired
-            exponent.
-
-        Raises:
-          ValueError: You tried to increase the exponent, which can't be
-            done without decryption.
-        """
-        if new_exp > self.exponent:
-            raise ValueError('New exponent %i should be more negative than'
-                             'old exponent %i' % (new_exp, self.exponent))
-        factor = pow(self.BASE, self.exponent - new_exp)
-        new_enc = self.encoding * factor % self.public_key.n
-        return self.__class__(self.public_key, new_enc, new_exp)
-
-
 class EncryptedNumber(object):
     """Represents the Paillier encryption of a float or int.
 
@@ -878,7 +628,7 @@ class EncryptedNumber(object):
           ValueError: if scalar is out of range or precision.
         """
         encoded = EncodedNumber.encode(self.public_key, scalar,
-                                        max_exponent=self.exponent)
+                                       max_exponent=self.exponent)
 
         return self._add_encoded(encoded)
 

--- a/phe/tests/paillier_test.py
+++ b/phe/tests/paillier_test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # Portions Copyright 2012 Google Inc. All Rights Reserved.
 # This file has been modified by NICTA
+import phe.encoding
 from phe.paillier import PaillierPrivateKey, PaillierPublicKey
 
 # This file is part of pyphe.
@@ -168,7 +169,7 @@ class PaillierTestEncodedNumber(PaillierTest):
 
     def setUp(self):
         super().setUp()
-        self.EncodedNumberCls = paillier.EncodedNumber
+        self.EncodedNumberCls = phe.encoding.EncodedNumber
 
 
     def testEncodeInt0(self):
@@ -391,7 +392,7 @@ class PaillierTestEncodedNumberAlternativeBaseLarge(PaillierTestEncodedNumber):
     def setUp(self):
         super().setUp()
 
-        class AltEncodedNumber(paillier.EncodedNumber):
+        class AltEncodedNumber(phe.encoding.EncodedNumber):
             BASE = 64
             LOG2_BASE = math.log(BASE, 2)
 
@@ -405,7 +406,7 @@ class PaillierTestEncodedNumberAlternativeBaseSmall(PaillierTestEncodedNumber):
     def setUp(self):
         super().setUp()
 
-        class AltEncodedNumber(paillier.EncodedNumber):
+        class AltEncodedNumber(phe.encoding.EncodedNumber):
             BASE = 2
             LOG2_BASE = math.log(BASE, 2)
 
@@ -419,7 +420,7 @@ class PaillierTestEncodedNumberAlternativeBaseOdd(PaillierTestEncodedNumber):
     def setUp(self):
         super().setUp()
 
-        class AltEncodedNumber(paillier.EncodedNumber):
+        class AltEncodedNumber(phe.encoding.EncodedNumber):
             BASE = 13
             LOG2_BASE = math.log(BASE, 2)
 
@@ -482,7 +483,7 @@ class PaillierTestEncryptedNumber(PaillierTest):
 
     def testCantAddEncodedWithDifferentKey(self):
         ciphertext1 = self.public_key.encrypt(-15)
-        ciphertext2 = paillier.EncodedNumber(self.other_public_key, 1, ciphertext1.exponent)
+        ciphertext2 = phe.encoding.EncodedNumber(self.other_public_key, 1, ciphertext1.exponent)
         self.assertRaises(ValueError, ciphertext1.__add__, ciphertext2)
 
     def testAddWithEncryptDecryptInt0(self):
@@ -645,7 +646,7 @@ class PaillierTestEncryptedNumber(PaillierTest):
     def testAddWithEncryptedIntAndEncodedNumber(self):
         # Add 1 to a small positive number
         ciphertext1 = self.public_key.encrypt(15)
-        encoded2 = paillier.EncodedNumber.encode(self.public_key, 1)
+        encoded2 = phe.encoding.EncodedNumber.encode(self.public_key, 1)
         ciphertext3 = ciphertext1 + encoded2
         decryption = self.private_key.decrypt(ciphertext3)
         self.assertEqual(16, decryption)
@@ -653,7 +654,7 @@ class PaillierTestEncryptedNumber(PaillierTest):
     def testAddWithEncryptedIntAndEncodedNumberDiffExp0(self):
         # Add 1 to a small positive number
         ciphertext1 = self.public_key.encrypt(15)
-        encoded2 = paillier.EncodedNumber.encode(self.public_key, 1, max_exponent=-50)
+        encoded2 = phe.encoding.EncodedNumber.encode(self.public_key, 1, max_exponent=-50)
         assert encoded2.exponent > -200
         assert ciphertext1.exponent > -200
 
@@ -665,7 +666,7 @@ class PaillierTestEncryptedNumber(PaillierTest):
         # Try with the EncryptedNumber having the smaller exponent
         ciphertext1 = self.public_key.encrypt(15)
         ciphertext2 = ciphertext1.decrease_exponent_to(-10)
-        encoded1 = paillier.EncodedNumber.encode(self.public_key, 1)
+        encoded1 = phe.encoding.EncodedNumber.encode(self.public_key, 1)
         encoded2 = encoded1.decrease_exponent_to(-10)
         ciphertext = ciphertext1.decrease_exponent_to(-200)
         assert encoded2.exponent == -10
@@ -677,7 +678,7 @@ class PaillierTestEncryptedNumber(PaillierTest):
     def testMulWithEncryptedIntAndEncodedNumber(self):
         # Multiply two negative integers
         ciphertext1 = self.public_key.encrypt(-3)
-        encoded2 = paillier.EncodedNumber.encode(self.public_key, -25)
+        encoded2 = phe.encoding.EncodedNumber.encode(self.public_key, -25)
         ciphertext3 = ciphertext1 * encoded2
         decryption = self.private_key.decrypt(ciphertext3)
         self.assertEqual(75, decryption)
@@ -910,14 +911,14 @@ class PaillierTestEncryptedNumber(PaillierTest):
         ciphertext2 = ciphertext1 * 31.4
         self.assertEqual(-3.14, self.private_key.decrypt(ciphertext2))
         self.assertNotEqual(ciphertext2.exponent, ciphertext1.exponent)
-        exp_of_314 = paillier.EncodedNumber.encode(self.public_key, -31.4).exponent
+        exp_of_314 = phe.encoding.EncodedNumber.encode(self.public_key, -31.4).exponent
         self.assertEqual(ciphertext2.exponent, ciphertext1.exponent +exp_of_314)
 
     def testMulWithEncryptedFloatAndEncodedNumber0(self):
         # Multiply a floatish with custom precision by a positive float
         ciphertext1 = self.public_key.encrypt(1.2345678e-12, precision=1e-14)
-        encoded1 = paillier.EncodedNumber.encode(self.public_key, 1.38734864,
-                                                 precision=1e-2)
+        encoded1 = phe.encoding.EncodedNumber.encode(self.public_key, 1.38734864,
+                                                     precision=1e-2)
         ciphertext2 = ciphertext1 * encoded1
         self.assertAlmostEqual(1.71e-12, self.private_key.decrypt(ciphertext2), places=3)
 
@@ -941,14 +942,14 @@ class PaillierTestEncryptedNumber(PaillierTest):
         ciphertext2 = ciphertext1 * -31.4
         self.assertEqual(3.14, self.private_key.decrypt(ciphertext2))
         self.assertNotEqual(ciphertext2.exponent, ciphertext1.exponent)
-        exp_of_314 = paillier.EncodedNumber.encode(self.public_key, -31.4).exponent
+        exp_of_314 = phe.encoding.EncodedNumber.encode(self.public_key, -31.4).exponent
         self.assertEqual(ciphertext2.exponent, ciphertext1.exponent +exp_of_314)
 
     def testMulWithEncryptedFloatAndEncodedNumber1(self):
         # Multiply a floatish with custom precision by a negative float
         ciphertext1 = self.public_key.encrypt(1.2345678e-12, precision=1e-14)
-        encoded1 = paillier.EncodedNumber.encode(self.public_key, -1.38734864,
-                                                 precision=1e-2)
+        encoded1 = phe.encoding.EncodedNumber.encode(self.public_key, -1.38734864,
+                                                     precision=1e-2)
         ciphertext2 = ciphertext1 * encoded1
         self.assertAlmostEqual(-1.71e-12, self.private_key.decrypt(ciphertext2), places=3)
 
@@ -985,8 +986,8 @@ class PaillierTestEncryptedNumber(PaillierTest):
     def testAddWithEncryptedFloatAndEncodedNumber(self):
         # Add two floats with different precisions
         ciphertext1 = self.public_key.encrypt(0.1, precision=1e-3)
-        encoded1 = paillier.EncodedNumber.encode(self.public_key, 0.2,
-                                                 precision=1e-20)
+        encoded1 = phe.encoding.EncodedNumber.encode(self.public_key, 0.2,
+                                                     precision=1e-20)
         self.assertNotEqual(ciphertext1.exponent, encoded1.exponent)
         old_exponent = ciphertext1.exponent
 
@@ -1001,11 +1002,11 @@ class PaillierTestEncryptedNumber(PaillierTest):
     def testMulWithEncryptedFloatAndEncodedNumber(self):
         # Multiply a floatish by an encoded negative float
         ciphertext1 = self.public_key.encrypt(-0.1)
-        encoded1 = paillier.EncodedNumber.encode(self.public_key, -31.4)
+        encoded1 = phe.encoding.EncodedNumber.encode(self.public_key, -31.4)
         ciphertext2 = ciphertext1 * encoded1
         self.assertEqual(3.14, self.private_key.decrypt(ciphertext2))
         self.assertNotEqual(ciphertext2.exponent, ciphertext1.exponent)
-        exp_of_314 = paillier.EncodedNumber.encode(self.public_key, -31.4).exponent
+        exp_of_314 = phe.encoding.EncodedNumber.encode(self.public_key, -31.4).exponent
         self.assertEqual(ciphertext2.exponent, ciphertext1.exponent +exp_of_314)
 
     def testObfuscate(self):


### PR DESCRIPTION
A small refactor to make #26 easier, just moves the current `EncodedNumber` into own file.