### PR TITLE
Remove gmpy2 as dependency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,16 @@ Or use nose::
 
    nosetests
 
+Note related to gmpy2
+---------------------
+
+`gmpy2` is not required to use the library, but is preferred. A pure Python implementation is available but 
+`gmpy2` drastically improves performances. As indication on a laptop not dedicated to benchmarking, running the example
+`examples/federated_learning_with_encryption.py` provided in the library took:
+ - 4.5s with `gmpy2` installed
+ - 35.7s without `gmpy2` installed
+
+However, `gmpy2` is a requirement to run the tests.
 
 Code History
 ------------

--- a/examples/federated_learning_with_encryption.py
+++ b/examples/federated_learning_with_encryption.py
@@ -138,7 +138,7 @@ class Server:
     """Private key holder. Decrypts the average gradient"""
 
     def __init__(self, key_length):
-         keypair = paillier.generate_paillier_keypair(key_length)
+         keypair = paillier.generate_paillier_keypair(n_length=key_length)
          self.pubkey, self.privkey = keypair
 
     def decrypt_aggregate(self, input_model, n_clients):

--- a/setup.py
+++ b/setup.py
@@ -56,9 +56,9 @@ setup(
     },
     extras_require={
         'cli': ['click'],
-        'examples': ['sklearn']
+        'examples': ['numpy', 'scipy', 'sklearn']
     },
-    install_requires=['gmpy2'],
-    tests_require=['numpy', 'click'],
+    install_requires=[],
+    tests_require=['click', 'gmpy2', 'numpy'],
     test_suite="phe.tests"
 )


### PR DESCRIPTION
Since the PR #57 has been merged in, phe installation does not require gmpy2.
Forgot to update the `setup.py` file.